### PR TITLE
Pluralize points and improve their display

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -177,7 +177,7 @@ class listener implements EventSubscriberInterface
 			'IDEA_VOTES'		=> $idea['idea_votes_up'] + $idea['idea_votes_down'],
 			'IDEA_VOTES_UP'		=> $idea['idea_votes_up'],
 			'IDEA_VOTES_DOWN'	=> $idea['idea_votes_down'],
-			'IDEA_POINTS'		=> $this->language->lang('VIEW_VOTES', $points),
+			'IDEA_POINTS'		=> $this->language->lang('TOTAL_POINTS', $points),
 			'IDEA_STATUS'		=> $this->ideas->get_status_from_id($idea['idea_status']),
 			'IDEA_STATUS_LINK'	=> $this->helper->route('phpbb_ideas_list_controller', array('status' => $idea['idea_status'])),
 

--- a/factory/ideas.php
+++ b/factory/ideas.php
@@ -504,7 +504,7 @@ class ideas
 				'message'	    => $this->language->lang('UPDATED_VOTE'),
 				'votes_up'	    => $idea['idea_votes_up'],
 				'votes_down'	=> $idea['idea_votes_down'],
-				'points'        => $idea['idea_votes_up'] - $idea['idea_votes_down']
+				'points'        => $this->language->lang('TOTAL_POINTS', $idea['idea_votes_up'] - $idea['idea_votes_down']),
 			);
 		}
 
@@ -531,7 +531,7 @@ class ideas
 			'message'	    => $this->language->lang('VOTE_SUCCESS'),
 			'votes_up'	    => $idea['idea_votes_up'],
 			'votes_down'	=> $idea['idea_votes_down'],
-			'points'        => $idea['idea_votes_up'] - $idea['idea_votes_down']
+			'points'        => $this->language->lang('TOTAL_POINTS', $idea['idea_votes_up'] - $idea['idea_votes_down']),
 		);
 	}
 
@@ -572,7 +572,7 @@ class ideas
 			'message'	    => $this->language->lang('UPDATED_VOTE'),
 			'votes_up'	    => $idea['idea_votes_up'],
 			'votes_down'	=> $idea['idea_votes_down'],
-			'points'        => $idea['idea_votes_up'] - $idea['idea_votes_down']
+			'points'        => $this->language->lang('TOTAL_POINTS', $idea['idea_votes_up'] - $idea['idea_votes_down']),
 		);
 	}
 

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -24,6 +24,7 @@ $lang = array_merge($lang, array(
 	'ALREADY_VOTED'			=> 'You have already voted on this idea.',
 
 	'CHANGE_STATUS'			=> 'Change status',
+	'CLICK_TO_VIEW'			=> 'Click to view votes.',
 
 	'DATE'					=> 'Date',
 	'DUPLICATE'				=> 'Duplicate',
@@ -61,7 +62,7 @@ $lang = array_merge($lang, array(
 	'POST_IDEA'				=> 'Post a new idea',
 
 	'RATING'                => 'Rating',
-	'REMOVE_VOTE'			=> 'Remove vote',
+	'REMOVE_VOTE'			=> 'Remove my vote',
 	'RETURN_IDEAS'			=> '%sReturn to Ideas%s',
 	'RFC'					=> 'RFC',
 	'RFC_ERROR'				=> 'RFC must be a topic on Area51.',
@@ -85,6 +86,10 @@ $lang = array_merge($lang, array(
 		1	=> '%d idea',
 		2	=> '%d ideas',
 	),
+	'TOTAL_POINTS'			=> array(
+		1	=> '%s point.',
+		2	=> '%s points.',
+	),
 
 	'UPDATED_VOTE'			=> 'Successfully updated vote',
 
@@ -95,7 +100,6 @@ $lang = array_merge($lang, array(
 	'VIEW_IMPLEMENTED'		=> 'View all implemented ideas',
 	'VIEW_LATEST'			=> 'View all open ideas',
 	'VIEW_TOP'				=> 'View all top rated ideas',
-	'VIEW_VOTES'            => '%s point(s). Click to view votes',
 	'VOTE'					=> 'Vote',
 	'VOTE_DOWN'				=> 'Vote Down',
 	'VOTE_ERROR'			=> 'An error occurred',

--- a/styles/prosilver/template/idea_body.html
+++ b/styles/prosilver/template/idea_body.html
@@ -16,22 +16,22 @@
 				<div class="rating">
 					<a <!-- IF S_CAN_VOTE-->href="{U_IDEA_VOTE}"<!-- ENDIF --> class="minivoteup <!-- IF S_CAN_VOTE-->voteup<!-- ELSE -->dead<!-- ENDIF -->" title="{L_VOTE_UP}" data-l-err="{L_ERROR}" data-l-msg="{L_VOTE_ERROR}{L_COLON}"><span>{IDEA_VOTES_UP}</span></a> &nbsp;
 					<a <!-- IF S_CAN_VOTE-->href="{U_IDEA_VOTE}"<!-- ENDIF --> class="minivotedown <!-- IF S_CAN_VOTE-->votedown<!-- ELSE -->dead<!-- ENDIF -->" title="{L_VOTE_DOWN}" data-l-err="{L_ERROR}" data-l-msg="{L_VOTE_ERROR}{L_COLON}"><span>{IDEA_VOTES_DOWN}</span></a>
-					<a href="#" class="votes" data-l-msg="«{L_VIEW_VOTES}»">«{IDEA_POINTS}»</a> <span class="successvoted" data-l-err="{L_VOTE_FAIL}"></span>
+					<a href="#" class="votes bg3" data-l-msg="{L_CLICK_TO_VIEW}">{IDEA_POINTS} {L_CLICK_TO_VIEW}</a> <span class="successvoted" data-l-err="{L_VOTE_FAIL}"></span>
 				</div>
 				<div class="clear"></div>
 				<div class="voteslist bg3">
 					<ul>
 						<!-- IF .votes_up -->
 						<li>
-							<strong>&#x25B2;{L_COLON}</strong> <!-- BEGIN votes_up -->{votes_up.USER}<!-- IF not votes_up.S_LAST_ROW -->, <!-- ENDIF --><!-- END votes_up -->
+							<i class="fa fa-fw fa-thumbs-up"></i> <!-- BEGIN votes_up -->{votes_up.USER}<!-- IF not votes_up.S_LAST_ROW -->, <!-- ENDIF --><!-- END votes_up -->
 						</li>
-						<!-- BEGIN votes_up --><!-- IF votes_up.S_VOTED and S_CAN_VOTE --><li><a href="{U_REMOVE_VOTE}" class="removevote" data-l-err="{L_ERROR}" data-l-msg="{L_VOTE_ERROR}{L_COLON}">{L_REMOVE_VOTE}</a></li><!-- ENDIF --><!-- END votes_up -->
+						<!-- BEGIN votes_up --><!-- IF votes_up.S_VOTED and S_CAN_VOTE --><li><i class="fa fa-fw fa-times"></i> <a href="{U_REMOVE_VOTE}" class="removevote" data-l-err="{L_ERROR}" data-l-msg="{L_VOTE_ERROR}{L_COLON}">{L_REMOVE_VOTE}</a></li><!-- ENDIF --><!-- END votes_up -->
 						<!-- ENDIF -->
 						<!-- IF .votes_down -->
 						<li>
-							<strong>&#x25BC;{L_COLON}</strong> <!-- BEGIN votes_down -->{votes_down.USER}<!-- IF not votes_down.S_LAST_ROW -->, <!-- ENDIF --><!-- END votes_down -->
+							<i class="fa fa-fw fa-thumbs-down"></i> <!-- BEGIN votes_down -->{votes_down.USER}<!-- IF not votes_down.S_LAST_ROW -->, <!-- ENDIF --><!-- END votes_down -->
 						</li>
-						<!-- BEGIN votes_down --><!-- IF votes_down.S_VOTED and S_CAN_VOTE --><li><a href="{U_REMOVE_VOTE}" class="removevote" data-l-err="{L_ERROR}" data-l-msg="{L_VOTE_ERROR}{L_COLON}">{L_REMOVE_VOTE}</a></li><!-- ENDIF --><!-- END votes_down -->
+						<!-- BEGIN votes_down --><!-- IF votes_down.S_VOTED and S_CAN_VOTE --><li><i class="fa fa-fw fa-times"></i> <a href="{U_REMOVE_VOTE}" class="removevote" data-l-err="{L_ERROR}" data-l-msg="{L_VOTE_ERROR}{L_COLON}">{L_REMOVE_VOTE}</a></li><!-- ENDIF --><!-- END votes_down -->
 						<!-- ENDIF -->
 					</ul>
 				</div>

--- a/styles/prosilver/template/ideas.js
+++ b/styles/prosilver/template/ideas.js
@@ -37,7 +37,7 @@
 			$obj.voteUp.first().html('<span>' + message.votes_up + '</span>');
 			$obj.voteDown.first().html('<span>' + message.votes_down + '</span>');
 			$obj.votes.hide().text(function() {
-				return $(this).attr('data-l-msg').replace('%s', message.points);
+				return message.points + ' ' + $(this).attr('data-l-msg');
 			});
 			$obj.successVoted.text(message.message)
 				.show()

--- a/styles/prosilver/theme/ideas.css
+++ b/styles/prosilver/theme/ideas.css
@@ -1,6 +1,8 @@
 a.votes {
 	font-weight: bold;
 	display: inline-block;
+	border-radius: 4px;
+	padding: 6px;
 }
 
 a.dead {


### PR DESCRIPTION
Finally found a way to properly pluralize the point(s) tally. At the same time, improved the look of the points tally and replaced up/down triangles with icon fonts for thumbs up and down.
![screen shot 2015-11-08 at 8 53 39 pm](https://cloud.githubusercontent.com/assets/303711/11026277/0920d352-865c-11e5-8b8f-2723808514a2.png)
