### PR TITLE
Make migration dependencies more strict

### DIFF
--- a/migrations/m4_update_statuses.php
+++ b/migrations/m4_update_statuses.php
@@ -26,7 +26,10 @@ class m4_update_statuses extends \phpbb\db\migration\migration
 
 	static public function depends_on()
 	{
-		return array('\phpbb\ideas\migrations\m2_initial_data');
+		return array(
+			'\phpbb\ideas\migrations\m1_initial_schema',
+			'\phpbb\ideas\migrations\m2_initial_data',
+		);
 	}
 
 	public function update_data()

--- a/migrations/m6_migrate_old_tables.php
+++ b/migrations/m6_migrate_old_tables.php
@@ -19,7 +19,10 @@ class m6_migrate_old_tables extends \phpbb\db\migration\migration
 
 	static public function depends_on()
 	{
-		return array('\phpbb\ideas\migrations\m4_update_statuses');
+		return array(
+			'\phpbb\ideas\migrations\m1_initial_schema',
+			'\phpbb\ideas\migrations\m4_update_statuses',
+		);
 	}
 
 	public function update_schema()

--- a/migrations/m7_drop_old_tables.php
+++ b/migrations/m7_drop_old_tables.php
@@ -19,7 +19,10 @@ class m7_drop_old_tables extends \phpbb\db\migration\migration
 
 	static public function depends_on()
 	{
-		return array('\phpbb\ideas\migrations\m6_migrate_old_tables');
+		return array(
+			'\phpbb\ideas\migrations\m1_initial_schema',
+			'\phpbb\ideas\migrations\m6_migrate_old_tables',
+		);
 	}
 
 	public function update_schema()


### PR DESCRIPTION
Currently, phpBB 3.2.0-rc2-dev does not allow this ext to uninstall without being more specific about each migration with schema changes depending on migration 1.